### PR TITLE
Update API to use UUID sessions

### DIFF
--- a/src/searchv2/session.py
+++ b/src/searchv2/session.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from threading import Lock, Thread
 from pathlib import Path
 from typing import Dict, Optional
+from uuid import UUID
 
 from .tools.human_input_tool import MessageBroker
 
@@ -23,12 +24,13 @@ class SessionManager:
     _lock: Lock = Lock()
 
     @classmethod
-    def get_session(cls, session_id: str) -> Session:
+    def get_session(cls, session_uuid: UUID) -> Session:
+        key = str(session_uuid)
         with cls._lock:
-            session = cls._sessions.get(session_id)
+            session = cls._sessions.get(key)
             if session is None:
                 session = Session(broker=MessageBroker())
-                cls._sessions[session_id] = session
+                cls._sessions[key] = session
             return session
 
     @classmethod


### PR DESCRIPTION
## Summary
- accept `UUID` objects when getting sessions
- update API endpoints and crew kickoff logic to use `session_uuid`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'crewai_tools')*

------
https://chatgpt.com/codex/tasks/task_e_68407ef89ed8833385a4f61a43591077