### PR TITLE
Add retry logic for empty LLM responses

### DIFF
--- a/src/searchv2/crew.py
+++ b/src/searchv2/crew.py
@@ -9,6 +9,45 @@ from searchv2.tools.trusted_medical_search_tool import TrustedMedicalSearchTool
 from crewai_tools import WebsiteSearchTool
 import os
 from pathlib import Path
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def _patch_agent_run_with_retry(max_retries: int = 2, delay: float = 1.0,
+                                fallback: str = "No response, please try again later."):
+    """Wrap Agent.run to retry on empty responses."""
+    if getattr(Agent, "_run_wrapped", False):
+        return
+
+    original_run = Agent.run
+
+    def run_with_retry(self, *args, **kwargs):
+        for attempt in range(1, max_retries + 1):
+            result = original_run(self, *args, **kwargs)
+            if result is not None and str(result).strip() != "":
+                return result
+            logger.warning(
+                "Empty response from agent '%s' (attempt %s/%s)",
+                getattr(self, "name", "unknown"),
+                attempt,
+                max_retries,
+            )
+            time.sleep(delay)
+
+        logger.error(
+            "Agent '%s' returned no response after %s attempts",
+            getattr(self, "name", "unknown"),
+            max_retries,
+        )
+        return fallback
+
+    Agent.run = run_with_retry
+    Agent._run_wrapped = True
+
+
+_patch_agent_run_with_retry()
 # If you want to run a snippet of code before or after the crew starts,
 # you can use the @before_kickoff and @after_kickoff decorators
 # https://docs.crewai.com/concepts/crews#example-crew-class-with-decorators


### PR DESCRIPTION
## Summary
- retry `Agent.run` when LLM returns an empty string or `None`
- log each retry and stop after a couple attempts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'crewai_tools')*

------
https://chatgpt.com/codex/tasks/task_e_6841b5364f9c83338974b5c4e09fb936