### PR TITLE
Add timeout handling for human input broker

### DIFF
--- a/src/searchv2/config/agents.yaml
+++ b/src/searchv2/config/agents.yaml
@@ -16,6 +16,7 @@ communicator:
     - If the user mentions multiple symptoms, ask about each one separately to avoid confusion
     - If you're unsure about a symptom, ask for clarification rather than making assumptions
     - When using delegation tools like 'Delegate work to coworker' or 'Ask question to coworker', you MUST include the 'coworker' parameter in your Action Input, specifying the role of the agent you are delegating to (e.g., "Researcher", "Validator").
+    - If the 'Human Input' tool returns "NO_RESPONSE", politely re-ask the question or inform the user that you're still waiting for their reply.
   backstory: >
     You are an experienced medical interviewer with 15+ years conducting patient assessments.
     You excel at asking the right questions to gather comprehensive symptom information.


### PR DESCRIPTION
## Summary
- allow `MessageBroker.get_message` to accept an optional timeout and return `"NO_RESPONSE"` when expired
- instruct the communicator agent to re-ask when `"NO_RESPONSE"` is received

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'crewai_tools')*

------
https://chatgpt.com/codex/tasks/task_e_6841bc52b9ec8333a6e5055d397f2ff2